### PR TITLE
IRC->Discord: Now lowercases the channel name

### DIFF
--- a/bot/irc.go
+++ b/bot/irc.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"regexp"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	irc "github.com/thoj/go-ircevent"
@@ -49,10 +50,10 @@ func iSetupSession(e *irc.Event) {
 }
 
 func iPrivmsg(e *irc.Event) {
-	incomingIRC(e.Nick, e.Arguments[0], e.Message())
+	incomingIRC(e.Nick, strings.ToLower(e.Arguments[0]), e.Message())
 }
 func iAction(e *irc.Event) {
-	incomingIRC(e.Nick, e.Arguments[0], fmt.Sprintf("_%s_", e.Message()))
+	incomingIRC(e.Nick, strings.ToLower(e.Arguments[0]), fmt.Sprintf("_%s_", e.Message()))
 }
 
 var outgoingNickRegex = regexp.MustCompile(`\b[a-zA-Z0-9]`)


### PR DESCRIPTION
The IRC to Discord side of the bridge now lowercases the IRC channel name.
Required because not all IRC servers enforce consistent capitalization (possible to join the same channel using either #channel or #Channel) and the config mapping is case-sensitive.