### PR TITLE
Add bot command handling

### DIFF
--- a/bot/bridge.go
+++ b/bot/bridge.go
@@ -45,7 +45,7 @@ func hasCommand(message string) bool {
 	for _, element := range commandCharacters {
 		//Assuming that the command character will always be the first character in the message,
 		//as well as there never being any null incoming messages.
-		if strings.Contains(splitMessage[0], strings.Split(element, "")[0]) {
+		if strings.Contains(strings.Split(splitMessage[0], "")[0], string(element)) {
 			hasCommand = true
 		}
 	}

--- a/bot/discord.go
+++ b/bot/discord.go
@@ -291,10 +291,11 @@ func (s StringReplaceGroup) Less(i, j int) bool {
 	return si < sj
 }
 
-func dOutgoing(nick, channel string, messageParsed format.FormattedString) {
+func dOutgoing(nick, channel string, messageParsed format.FormattedString, anonymous bool) {
 	chanParts := strings.Split(channel, "#")
 	guildID := dGuilds[chanParts[0]]
 	chanID := dGuildChans[chanParts[0]][chanParts[1]]
+	outgoingMessage := ""
 
 	g, err := dSession.Guild(guildID)
 	if err != nil {
@@ -344,8 +345,14 @@ func dOutgoing(nick, channel string, messageParsed format.FormattedString) {
 		message = strings.Replace(message, find, replace, -1)
 	}
 
+	if anonymous {
+		outgoingMessage = message
+	} else {
+		outgoingMessage = fmt.Sprintf("**<%s>** %s", nick, message)
+	}
+
 	dMsgQueue <- func() {
-		_, err := dSession.ChannelMessageSend(chanID, fmt.Sprintf("**<%s>** %s", nick, message))
+		_, err := dSession.ChannelMessageSend(chanID, outgoingMessage)
 		if err != nil {
 			log.Errorf("Failed to send message to %s: <%s> %s", chanID, nick, message)
 		}

--- a/conf.json.example
+++ b/conf.json.example
@@ -6,6 +6,7 @@
 		"ssl": true,
 		"ssl_verify": true,
 		"server": "irc.example.com:6697"
+		"command_chars": "?!"
 	},
 	"discord": {
 		"token": "DISCORD-TOKEN-GOES-HERE",
@@ -16,6 +17,5 @@
 		"#my-other-irc-channel": "my-discord-server-name#otherchannel",
 
 		"#other-discord": "second-discord-server#general"
-	}
-}
+	},}
 


### PR DESCRIPTION
Greetings, and thanks for your effort on this bot <3

This pull request adds command handling to the link bot.

In short, most IRC/Discord bots require that their trigger command (a string prefixed with ? or ! or something) is the first word of a message. Since the linkbot prefixes all messages with the name of the sender, I taught it to recognize command prefixes (with a list in the config file), and send any of those messages out without a username attached. For identity, it will say "Command send by (name)" before the non-username-prefixed message is transmitted on its own.